### PR TITLE
version 0.4-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3.3-SHAPSHOT]
+## [0.4-SHAPSHOT]
+### Changed
+- using scala CanBuildFrom for support any sequence and map
 
 ## [0.3.2] - 2017-11-16
 ### Added

--- a/src/test/scala/com/github/sergeygrigorev/util/JsonObjectOpsTest.scala
+++ b/src/test/scala/com/github/sergeygrigorev/util/JsonObjectOpsTest.scala
@@ -21,6 +21,8 @@ import com.github.sergeygrigorev.util.syntax.gson._
 import com.google.gson._
 import org.scalatest.FlatSpec
 
+import scala.collection.mutable
+
 /**
  * Examples and unit tests for [[com.github.sergeygrigorev.util.syntax]].
  */
@@ -71,14 +73,26 @@ class JsonObjectOpsTest extends FlatSpec {
     assert(jsonObject.find[JsonObject]("a").isEmpty)
   }
 
-  it should "decode list of primitives" in {
+  it should "decode sequences" in {
     val jsonObject = parse("{a: [1, 2, 3] }")
     assert(jsonObject.getAs[List[Int]]("a") == List(1, 2, 3))
+    assert(jsonObject.getAs[Set[Int]]("a") == Set(1, 2, 3))
+    assert(jsonObject.getAs[Stream[Int]]("a") == Stream(1, 2, 3))
+
+    import scala.collection.mutable
+    assert(jsonObject.getAs[mutable.Set[Int]]("a") == mutable.Set(1, 2, 3))
+    assert(jsonObject.getAs[mutable.ArrayBuffer[Int]]("a") == mutable.ArrayBuffer(1, 2, 3))
   }
 
-  it should "decode map of primitives" in {
+  it should "decode maps" in {
     val jsonObject = parse("{a: { b: 1, c: 2 } }")
-    assert(jsonObject.getAs[Map[String, Int]]("a") == Map("b" -> 1, "c" -> 2))
+    import scala.collection.immutable
+    assert(jsonObject.getAs[immutable.Map[String, Int]]("a") == immutable.Map("b" -> 1, "c" -> 2))
+    assert(jsonObject.getAs[immutable.TreeMap[String, Int]]("a") == immutable.TreeMap("b" -> 1, "c" -> 2))
+    assert(jsonObject.getAs[immutable.HashMap[String, Int]]("a") == immutable.HashMap("b" -> 1, "c" -> 2))
+
+    import scala.collection.mutable
+    assert(jsonObject.getAs[mutable.Map[String, Int]]("a") == mutable.Map("b" -> 1, "c" -> 2))
   }
 
   it should "decode custom type with manually created format" in {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.3-SNAPSHOT"
+version in ThisBuild := "0.4-SNAPSHOT"


### PR DESCRIPTION
- the coproduct decoder now uses a simple pipeline instead a map and type cast
- support any kind of sequences and maps (relies on CanBuildFrom)